### PR TITLE
Re-add allow plugins parameter in all instances of the Chromium command line

### DIFF
--- a/start_wrapper.bat
+++ b/start_wrapper.bat
@@ -743,9 +743,9 @@ if !INCLUDEDCHROMIUM!==n (
 	echo Opening Wrapper: Offline using included Chromium...
 	pushd utilities\ungoogled-chromium
 	if !APPCHROMIUM!==y (
-		if !DRYRUN!==n ( start chrome.exe --user-data-dir=the_profile --app=http://localhost:4343 )
+		if !DRYRUN!==n ( start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile --app=http://localhost:4343 )
 	) else (
-		if !DRYRUN!==n ( start chrome.exe --user-data-dir=the_profile http://localhost:4343 )
+		if !DRYRUN!==n ( start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile http://localhost:4343 )
 	)
 	popd
 )
@@ -830,9 +830,9 @@ if !INCLUDEDCHROMIUM!==n (
 	echo Opening Wrapper: Offline using included Chromium...
 	pushd utilities\ungoogled-chromium
 	if !APPCHROMIUM!==y (
-		start chrome.exe --user-data-dir=the_profile --app=http://localhost:4343 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile --app=http://localhost:4343 >nul
 	) else (
-		start chrome.exe --user-data-dir=the_profile http://localhost:4343 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile http://localhost:4343 >nul
 	)
 	popd
 )
@@ -851,9 +851,9 @@ if !INCLUDEDCHROMIUM!==n (
 	echo Opening the server page using included Chromium...
 	pushd utilities\ungoogled-chromium
 	if !APPCHROMIUM!==y (
-		start chrome.exe --user-data-dir=the_profile --app=https://localhost:4664 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile --app=https://localhost:4664 >nul
 	) else (
-		start chrome.exe --user-data-dir=the_profile https://localhost:4664 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile https://localhost:4664 >nul
 	)
 	popd
 )


### PR DESCRIPTION
Only 1 of the 7 instances of the Chromium command line have the allow plugins parameter, causing users to have to confirm Flash every time the video maker, character creator, character browser, or player is used. I am re-adding the parameter to all 7 instances of the Chromium command line.